### PR TITLE
Fix focus detection grep to use literal string match

### DIFF
--- a/notify.sh
+++ b/notify.sh
@@ -67,7 +67,7 @@ tell application "System Events"
     end try
 end tell' 2>/dev/null)
 if echo "$ax_value" | grep -q "Claude Code"; then
-  if [ -n "$cwd" ] && echo "$ax_value" | grep -q "$cwd"; then
+  if [ -n "$cwd" ] && echo "$ax_value" | grep -qF "$cwd"; then
     is_focused=true
   fi
 fi


### PR DESCRIPTION
## Summary
- Use `grep -qF` instead of `grep -q` in `notify.sh` line 70 to treat the `$cwd` pattern as a fixed/literal string
- Prevents false positives when directory names contain regex metacharacters (`.`, `+`, `*`, etc.)

Fixes #3

## Test plan
- [ ] Create a directory with regex metacharacters in the name (e.g., `my.project` or `app+v2`)
- [ ] Run Claude Code from that directory and verify focus detection works correctly
- [ ] Verify no false positives from partial regex matches (e.g., `my.project` no longer matches `my-project`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)